### PR TITLE
Initialize TLS and MultiSet entries during grow

### DIFF
--- a/src/unthread.c
+++ b/src/unthread.c
@@ -536,7 +536,7 @@ static void multiset_grow(struct pthread_multiset *set) {
   }
 
   struct pthread_multiset new_set = (struct pthread_multiset){
-      .entries = malloc(new_cap * sizeof(struct pthread_multiset_entry)),
+      .entries = calloc(new_cap, sizeof(struct pthread_multiset_entry)),
       .cap = new_cap,
       .len = 0,
   };
@@ -1684,7 +1684,7 @@ static void tls_grow(struct tls *tls) {
   }
 
   struct tls new_tls = (struct tls){
-      .entries = malloc(new_cap * sizeof(struct tls_entry)),
+      .entries = calloc(new_cap, sizeof(struct tls_entry)),
       .cap = new_cap,
       .len = 0,
   };


### PR DESCRIPTION
When adding a single entry to a fresh TLS or MultiSet, unused entries will be uninitialized memory. This was discovered during running a POSIX test, which would never finish due to an infinite loop in tls_insert_base, as it was comparing undefined key values.