### PR TITLE
Increase constructor priority over other global initializers

### DIFF
--- a/src/unthread.c
+++ b/src/unthread.c
@@ -246,7 +246,7 @@ static FILE *noise_file;
 // State for PRGN-based entropy
 static uint32_t noise_prng_state[4];
 
-void __attribute__((constructor)) pthread_constructor() {
+void __attribute__((constructor(1000))) pthread_constructor() {
   const char *verbose_str = getenv(VERBOSE_ENV);
   verbose = (verbose_str != NULL && strcmp(verbose_str, "true") == 0);
 


### PR DESCRIPTION
When running from a C++ environment, constructors of global data under GCC will execute before unthread has been initialized. By increasing the constructor priority, this can be avoided. Before this, I also tried using `.preinit_array` but this ended up not working as `environ` has not been initialized at that time in glibc. Setting the priority to 1000 seems like a hack, but values 0-100 are reserved for the implementation.